### PR TITLE
Add test for enum-based ADT

### DIFF
--- a/src/test/scala/co.blocke.scala_reflection/Enums.scala
+++ b/src/test/scala/co.blocke.scala_reflection/Enums.scala
@@ -26,13 +26,22 @@ class Enums extends munit.FunSuite:
   test("Scala Enum methods") {
     val result = RType.of[Birthday]
     result match {
-      case sc: ScalaCaseClassInfo => 
+      case sc: ScalaCaseClassInfo =>
         val e = sc.fields(0).asInstanceOf[ScalaFieldInfo].fieldType.asInstanceOf[ScalaEnumInfo]
-        assertEquals( e.valueOf("Jan"), Month.Jan )
-        assertEquals( e.ordinal("Feb"), 1 )
-        assertEquals( e.valueOf(2), Month.Mar )
+        assertEquals(e.valueOf("Jan"), Month.Jan)
+        assertEquals(e.ordinal("Feb"), 1)
+        assertEquals(e.valueOf(2), Month.Mar)
       case _ => false
     }
+  }
+
+  test("Scala Enum ADT") {
+    val result = RType.of[ColorSet]
+    assertEquals(result.show(),
+      """ScalaCaseClassInfo(co.blocke.scala_reflection.ColorSet):
+        |   fields:
+        |      (0) set: SeqLikeInfo(scala.collection.immutable.Set): ScalaEnumInfo(co.blocke.scala_reflection.Color) with values [Red,Green,Blue,Mix]
+        |""".stripMargin)
   }
 
   test("Scala2 Enumeration methods") {

--- a/src/test/scala/co.blocke.scala_reflection/Enums.scala
+++ b/src/test/scala/co.blocke.scala_reflection/Enums.scala
@@ -28,9 +28,9 @@ class Enums extends munit.FunSuite:
     result match {
       case sc: ScalaCaseClassInfo =>
         val e = sc.fields(0).asInstanceOf[ScalaFieldInfo].fieldType.asInstanceOf[ScalaEnumInfo]
-        assertEquals(e.valueOf("Jan"), Month.Jan)
-        assertEquals(e.ordinal("Feb"), 1)
-        assertEquals(e.valueOf(2), Month.Mar)
+        assertEquals( e.valueOf("Jan"), Month.Jan )
+        assertEquals( e.ordinal("Feb"), 1 )
+        assertEquals( e.valueOf(2), Month.Mar )
       case _ => false
     }
   }

--- a/src/test/scala/co.blocke.scala_reflection/Model.scala
+++ b/src/test/scala/co.blocke.scala_reflection/Model.scala
@@ -1,6 +1,7 @@
 package co.blocke.scala_reflection
 
 import co.blocke.reflect.*
+
 import scala.util.Try
 
 // Basic Tasty class
@@ -112,6 +113,15 @@ enum Month {
 }
 
 case class Birthday(m: Month, d: WeekDay)
+
+enum Color(val rgb: Int) {
+  case Red extends Color(0xFF0000)
+  case Green extends Color(0x00FF00)
+  case Blue extends Color(0x0000FF)
+  case Mix(mix: Int) extends Color(mix)
+}
+
+case class ColorSet(set: Set[Color])
 
 case class TryMe(maybe: scala.util.Try[Boolean])
 


### PR DESCRIPTION
I found that enums that describe ADTs behave a little differently from simpler (value-based) enums.

This lib does a good job with these ADTs. I just thought adding a regression test was useful.

These 2 methods don't exist with this type of enum:
  private lazy val valuesMethod  = infoClass.getMethod("values")
  private lazy val valueOfMethod = infoClass.getMethod("valueOf", classOf[String])

So some of the functions on ScalaEnumInfo don't work with this example.